### PR TITLE
Setting speed for all videos not just the first.

### DIFF
--- a/inject-playback-speed.js
+++ b/inject-playback-speed.js
@@ -13,12 +13,15 @@ browser.storage.onChanged.addListener((settings) => {
 
 // Set the playback speed
 function setPlaybackSpeed() {
-    function onGot(val) {        
+    function onGot(val) {
         let videoElementList = document.getElementsByTagName("video")
         if (videoElementList.length > 0)
         {
             console.info(`Set playback speed.  It is ${val["playback_speed"]}.`)
-            videoElementList[0].playbackRate=val["playback_speed"] || 1
+            for(var i = 0; i < videoElementList.length; i++)
+            {
+                videoElementList[i].playbackRate=val["playback_speed"] || 1
+            }
         }
     }
 


### PR DESCRIPTION
I sometimes have the problem that the YouTube video I'm watching is not the first one in the list of all videos and that then the add-on doesn't recognize it.  I then have to manually adjust the speed using the developer console (with `document.querySelectorAll("video").forEach(function(x) { x.playbackRate=2.5; })`), which works but is annoying with time.  This PR tries to fix that.
